### PR TITLE
Allow using the noImplicitAny option in TypeScript

### DIFF
--- a/lib/amqp-ts.d.ts
+++ b/lib/amqp-ts.d.ts
@@ -2,32 +2,6 @@
 
 import * as Promise from "bluebird";
 
-export declare var log: any;
-export declare class Connection {
-    initialized: Promise<void>;
-    private url;
-    private socketOptions;
-    private reconnectStrategy;
-    private connectedBefore;
-
-    constructor(url?: string, socketOptions?: any, reconnectStrategy?: Connection.ReconnectStrategy);
-    private rebuildConnection();
-    private tryToConnect(thisConnection, retry, callback);
-    close(): Promise<void>;
-    /**
-     * Make sure the whole defined connection topology is configured:
-     * return promise that fulfills after all defined exchanges, queues and bindings are initialized
-     */
-    completeConfiguration(): Promise<any>;
-    /**
-     * Delete the whole defined connection topology:
-     * return promise that fulfills after all defined exchanges, queues and bindings have been removed
-     */
-    deleteConfiguration(): Promise<any>;
-    declareExchange(name: string, type?: string, options?: Exchange.DeclarationOptions): Exchange;
-    declareQueue(name: string, options?: Queue.DeclarationOptions): Queue;
-    declareTopology(topology: Connection.Topology): Promise<any>;
-}
 export declare namespace Connection {
     interface ReconnectStrategy {
         retries: number;
@@ -52,6 +26,32 @@ export declare namespace Connection {
         }[];
     }
 }
+export declare class Connection {
+    initialized: Promise<void>;
+    
+    private url;
+    private socketOptions;
+    private reconnectStrategy;
+    private connectedBefore;
+
+    constructor(url?: string, socketOptions?: any, reconnectStrategy?: Connection.ReconnectStrategy);
+    private rebuildConnection();
+    private tryToConnect(thisConnection, retry, callback);
+    close(): Promise<void>;
+    /**
+     * Make sure the whole defined connection topology is configured:
+     * return promise that fulfills after all defined exchanges, queues and bindings are initialized
+     */
+    completeConfiguration(): Promise<any>;
+    /**
+     * Delete the whole defined connection topology:
+     * return promise that fulfills after all defined exchanges, queues and bindings have been removed
+     */
+    deleteConfiguration(): Promise<any>;
+    declareExchange(name: string, type?: string, options?: Exchange.DeclarationOptions): Exchange;
+    declareQueue(name: string, options?: Queue.DeclarationOptions): Queue;
+    declareTopology(topology: Connection.Topology): Promise<any>;
+}
 export declare class Message {
     content: Buffer;
     fields: any;
@@ -64,6 +64,18 @@ export declare class Message {
     ack(allUpTo?: boolean): void;
     nack(requeue?: boolean): void;
     reject(requeue?: boolean): void;
+}
+export declare namespace Exchange {
+    interface DeclarationOptions {
+        durable?: boolean;
+        internal?: boolean;
+        autoDelete?: boolean;
+        alternateExchange?: string;
+        arguments?: any;
+    }
+    export interface InitializeResult {
+        exchange: string;
+    }
 }
 export declare class Exchange {
     initialized: Promise<Exchange.InitializeResult>;
@@ -87,41 +99,6 @@ export declare class Exchange {
     activateConsumer(onMessage: (msg: Message) => any, options?: Queue.ActivateConsumerOptions): Promise<any>;
     stopConsumer(): Promise<any>;
 }
-export declare namespace Exchange {
-    interface DeclarationOptions {
-        durable?: boolean;
-        internal?: boolean;
-        autoDelete?: boolean;
-        alternateExchange?: string;
-        arguments?: any;
-    }
-    export interface InitializeResult {
-        exchange: string;
-    }
-}
-export declare class Queue {
-    initialized: Promise<Queue.InitializeResult>;
-
-    constructor(connection: Connection, name: string, options?: Queue.DeclarationOptions);
-    /**
-     * deprecated, use 'queue.send(message: Message)' instead
-     */
-    publish(content: any, options?: any): void;
-    send(message: Message, routingKey?: string): void;
-    rpc(requestParameters: any): Promise<Message>;
-    prefetch(count: number): void;
-    recover(): Promise<void>;
-    /**
-     * deprecated, use 'queue.activateConsumer(...)' instead
-     */
-    startConsumer(onMessage: (msg: any, channel?: any) => any, options?: Queue.StartConsumerOptions): Promise<Queue.StartConsumerResult>;
-    activateConsumer(onMessage: (msg: Message) => any, options?: Queue.ActivateConsumerOptions): Promise<Queue.StartConsumerResult>;
-    stopConsumer(): Promise<void>;
-    delete(): Promise<Queue.DeleteResult>;
-    close(): Promise<void>;
-    bind(source: Exchange, pattern?: string, args?: any): Promise<Binding>;
-    unbind(source: Exchange, pattern?: string, args?: any): Promise<void>;
-}
 export declare namespace Queue {
     interface DeclarationOptions {
         exclusive?: boolean;
@@ -134,8 +111,7 @@ export declare namespace Queue {
         maxLength?: number;
         prefetch?: number;
     }
-    interface StartConsumerOptions {
-        rawMessage?: boolean;
+    interface ActivateConsumerOptions {
         consumerTag?: string;
         noLocal?: boolean;
         noAck?: boolean;
@@ -143,7 +119,8 @@ export declare namespace Queue {
         priority?: number;
         arguments?: Object;
     }
-    interface ActivateConsumerOptions {
+    interface StartConsumerOptions {
+        rawMessage?: boolean;
         consumerTag?: string;
         noLocal?: boolean;
         noAck?: boolean;
@@ -163,6 +140,29 @@ export declare namespace Queue {
         messageCount: number;
     }
 }
+export declare class Queue {
+    initialized: Promise<Queue.InitializeResult>;
+
+    constructor(connection: Connection, name: string, options?: Queue.DeclarationOptions);
+    /**
+     * deprecated, use 'queue.send(message: Message)' instead
+     */
+    publish(content: any, options?: any): void;
+    send(message: Message, routingKey?: string): void;
+    rpc(requestParameters: any): Promise<Message>;
+    /**
+     * deprecated, use 'queue.activateConsumer(...)' instead
+     */
+    startConsumer(onMessage: (msg: any, channel?: any) => any, options?: Queue.StartConsumerOptions): Promise<Queue.StartConsumerResult>;
+    activateConsumer(onMessage: (msg: Message) => any, options?: Queue.ActivateConsumerOptions): Promise<Queue.StartConsumerResult>;
+    stopConsumer(): Promise<void>;
+    delete(): Promise<Queue.DeleteResult>;
+    close(): Promise<void>;
+    bind(source: Exchange, pattern?: string, args?: any): Promise<Binding>;
+    unbind(source: Exchange, pattern?: string, args?: any): Promise<void>;
+    prefetch(count: number): void;
+    recover(): Promise<void>;
+}
 export declare class Binding {
     initialized: Promise<Binding>;
 
@@ -171,3 +171,7 @@ export declare class Binding {
     static id(destination: Exchange | Queue, source: Exchange, pattern?: string): string;
     static removeBindingsContaining(connectionPoint: Exchange | Queue): Promise<any>;
 }
+/**
+ * winston Logger instance
+ */
+export declare var log: any;

--- a/lib/amqp-ts.d.ts
+++ b/lib/amqp-ts.d.ts
@@ -34,21 +34,21 @@ export declare namespace Connection {
         interval: number;
     }
     export interface Topology {
-        exchanges: {
-            name: string;
-            type?: string;
-            options?: any;
+        exchanges?: {
+            name: string,
+            type?: string,
+            options?: any
         }[];
-        queues: {
-            name: string;
-            options?: any;
+        queues?: {
+            name: string,
+            options?: any
         }[];
-        bindings: {
-            source: string;
-            queue?: string;
-            exchange?: string;
-            pattern?: string;
-            args?: any;
+        bindings?: {
+            source: string,
+            queue?: string,
+            exchange?: string,
+            pattern?: string,
+            args?: any
         }[];
     }
 }

--- a/lib/amqp-ts.d.ts
+++ b/lib/amqp-ts.d.ts
@@ -1,35 +1,18 @@
-/**
- * AmqpSimple.ts - provides a simple interface to read from and write to RabbitMQ amqp exchanges
- * Created by Ab on 17-9-2015.
- *
- * methods and properties starting with '_' signify that the scope of the item should be limited to
- * the inside of the enclosing namespace.
- */
-import * as AmqpLib from "amqplib/callback_api";
+// exported Typescript type definition for AmqpSimple
+
 import * as Promise from "bluebird";
-import * as winston from "winston";
-export declare var log: winston.LoggerInstance;
+
+export declare var log: any;
 export declare class Connection {
     initialized: Promise<void>;
     private url;
     private socketOptions;
     private reconnectStrategy;
     private connectedBefore;
-    _connection: AmqpLib.Connection;
-    _rebuilding: boolean;
-    _exchanges: {
-        [id: string]: Exchange;
-    };
-    _queues: {
-        [id: string]: Queue;
-    };
-    _bindings: {
-        [id: string]: Binding;
-    };
+
     constructor(url?: string, socketOptions?: any, reconnectStrategy?: Connection.ReconnectStrategy);
     private rebuildConnection();
     private tryToConnect(thisConnection, retry, callback);
-    _rebuildAll(err: Error): Promise<void>;
     close(): Promise<void>;
     /**
      * Make sure the whole defined connection topology is configured:
@@ -50,7 +33,7 @@ export declare namespace Connection {
         retries: number;
         interval: number;
     }
-    interface Topology {
+    export interface Topology {
         exchanges: {
             name: string;
             type?: string;
@@ -73,8 +56,7 @@ export declare class Message {
     content: Buffer;
     fields: any;
     properties: any;
-    _channel: AmqpLib.Channel;
-    _message: AmqpLib.Message;
+
     constructor(content?: any, options?: any);
     setContent(content: any): void;
     getContent(): any;
@@ -85,15 +67,8 @@ export declare class Message {
 }
 export declare class Exchange {
     initialized: Promise<Exchange.InitializeResult>;
-    _connection: Connection;
-    _channel: AmqpLib.Channel;
-    _name: string;
-    _type: string;
-    _options: AmqpLib.Options.AssertExchange;
-    _deleting: Promise<void>;
-    _closing: Promise<void>;
+
     constructor(connection: Connection, name: string, type?: string, options?: Exchange.DeclarationOptions);
-    _initialize(): void;
     /**
      * deprecated, use 'exchange.send(message: Message)' instead
      */
@@ -108,7 +83,7 @@ export declare class Exchange {
     /**
      * deprecated, use 'exchange.activateConsumer(...)' instead
      */
-    startConsumer(onMessage: (msg: any, channel?: AmqpLib.Channel) => any, options?: Queue.StartConsumerOptions): Promise<any>;
+    startConsumer(onMessage: (msg: any, channel?: any) => any, options?: Queue.StartConsumerOptions): Promise<any>;
     activateConsumer(onMessage: (msg: Message) => any, options?: Queue.ActivateConsumerOptions): Promise<any>;
     stopConsumer(): Promise<any>;
 }
@@ -120,28 +95,14 @@ export declare namespace Exchange {
         alternateExchange?: string;
         arguments?: any;
     }
-    interface InitializeResult {
+    export interface InitializeResult {
         exchange: string;
     }
 }
 export declare class Queue {
     initialized: Promise<Queue.InitializeResult>;
-    _connection: Connection;
-    _channel: AmqpLib.Channel;
-    _name: string;
-    _options: Queue.DeclarationOptions;
-    _consumer: (msg: any, channel?: AmqpLib.Channel) => any;
-    _isStartConsumer: boolean;
-    _rawConsumer: boolean;
-    _consumerOptions: Queue.StartConsumerOptions;
-    _consumerTag: string;
-    _consumerInitialized: Promise<Queue.StartConsumerResult>;
-    _deleting: Promise<Queue.DeleteResult>;
-    _closing: Promise<void>;
+
     constructor(connection: Connection, name: string, options?: Queue.DeclarationOptions);
-    _initialize(): void;
-    static _packMessageContent(content: any, options: any): Buffer;
-    static _unpackMessageContent(msg: AmqpLib.Message): any;
     /**
      * deprecated, use 'queue.send(message: Message)' instead
      */
@@ -153,9 +114,8 @@ export declare class Queue {
     /**
      * deprecated, use 'queue.activateConsumer(...)' instead
      */
-    startConsumer(onMessage: (msg: any, channel?: AmqpLib.Channel) => any, options?: Queue.StartConsumerOptions): Promise<Queue.StartConsumerResult>;
+    startConsumer(onMessage: (msg: any, channel?: any) => any, options?: Queue.StartConsumerOptions): Promise<Queue.StartConsumerResult>;
     activateConsumer(onMessage: (msg: Message) => any, options?: Queue.ActivateConsumerOptions): Promise<Queue.StartConsumerResult>;
-    _initializeConsumer(): void;
     stopConsumer(): Promise<void>;
     delete(): Promise<Queue.DeleteResult>;
     close(): Promise<void>;
@@ -194,7 +154,7 @@ export declare namespace Queue {
     interface StartConsumerResult {
         consumerTag: string;
     }
-    interface InitializeResult {
+    export interface InitializeResult {
         queue: string;
         messageCount: number;
         consumerCount: number;
@@ -205,12 +165,8 @@ export declare namespace Queue {
 }
 export declare class Binding {
     initialized: Promise<Binding>;
-    _source: Exchange;
-    _destination: Exchange | Queue;
-    _pattern: string;
-    _args: any;
+
     constructor(destination: Exchange | Queue, source: Exchange, pattern?: string, args?: any);
-    _initialize(): void;
     delete(): Promise<void>;
     static id(destination: Exchange | Queue, source: Exchange, pattern?: string): string;
     static removeBindingsContaining(connectionPoint: Exchange | Queue): Promise<any>;

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -115,7 +115,7 @@ export class Connection {
           callback(err);
         }
       } else {
-        var restart = (err) => {
+        var restart = (err: Error) => {
           amqpts_log.log("debug", "Connection error occurred.", {module: "amqp-ts"});
           connection.removeListener("error", restart);
           //connection.removeListener("end", restart); // not sure this is needed
@@ -130,7 +130,7 @@ export class Connection {
     });
   }
 
-  _rebuildAll(err): Promise<void> {
+  _rebuildAll(err: Error): Promise<void> {
     amqpts_log.log("warn", "Connection error: " + err.message, {module: "amqp-ts"});
 
     amqpts_log.log("debug", "Rebuilding connection NOW.", {module: "amqp-ts"});
@@ -192,7 +192,7 @@ export class Connection {
    * return promise that fulfills after all defined exchanges, queues and bindings are initialized
    */
   completeConfiguration(): Promise<any> {
-    var promises = [];
+    var promises: Promise<any>[] = [];
     for (var exchangeId in this._exchanges) {
       var exchange: Exchange = this._exchanges[exchangeId];
       promises.push(exchange.initialized);
@@ -216,7 +216,7 @@ export class Connection {
    * return promise that fulfills after all defined exchanges, queues and bindings have been removed
    */
   deleteConfiguration(): Promise<any> {
-    var promises = [];
+    var promises: Promise<any>[] = [];
     for (var bindingId in this._bindings) {
       var binding: Binding = this._bindings[bindingId];
       promises.push(binding.delete());
@@ -252,7 +252,7 @@ export class Connection {
   }
 
   declareTopology(topology: Connection.Topology): Promise<any> {
-    var promises = [];
+    var promises: Promise<any>[] = [];
     var i: number;
     var len: number;
 
@@ -272,7 +272,7 @@ export class Connection {
       for (i = 0, len = topology.bindings.length; i < len; i++) {
         var binding = topology.bindings[i];
         var source = this.declareExchange(binding.source);
-        var destination;
+        var destination: Queue | Exchange;
         if (binding.exchange !== undefined) {
           destination = this.declareExchange(binding.exchange);
         } else {
@@ -357,7 +357,7 @@ export class Message {
       }
     };
 
-    var exchange;
+    var exchange: string;
     if (destination instanceof Queue) {
       exchange = "";
       routingKey = destination._name;
@@ -474,7 +474,7 @@ export class Exchange {
   rpc(requestParameters: any, routingKey = ""): Promise<Message> {
     return new Promise<Message>((resolve, reject) => {
       var processRpc = () => {
-        var consumerTag;
+        var consumerTag: string;
         this._channel.consume(DIRECT_REPLY_TO_QUEUE, (resultMsg) => {
           this._channel.cancel(consumerTag);
           var result = new Message(resultMsg.content, resultMsg.fields);
@@ -585,7 +585,7 @@ export class Exchange {
         reject(new Error("amqp-ts Exchange.startConsumer error: consumer already defined"));
       });
     } else {
-      var promises = [];
+      var promises: Promise<any>[] = [];
       var queue = this._connection.declareQueue(queueName, {durable: false});
       promises.push(queue.initialized);
       var binding = queue.bind(this);
@@ -604,7 +604,7 @@ export class Exchange {
         reject(new Error("amqp-ts Exchange.activateConsumer error: consumer already defined"));
       });
     } else {
-      var promises = [];
+      var promises: Promise<any>[] = [];
       var queue = this._connection.declareQueue(queueName, {durable: false});
       promises.push(queue.initialized);
       var binding = queue.bind(this);
@@ -620,7 +620,7 @@ export class Exchange {
     var queue = this._connection._queues[this.consumerQueueName()];
     if (queue) {
       var binding = this._connection._bindings[Binding.id(queue, this)];
-      var promises = [];
+      var promises: Promise<any>[] = [];
       promises.push(queue.stopConsumer());
       promises.push(binding.delete());
       promises.push(queue.delete());
@@ -704,7 +704,7 @@ export class Queue {
     });
   }
 
-  static _packMessageContent(content, options): Buffer {
+  static _packMessageContent(content: any, options: any): Buffer {
     if (typeof content === "string") {
       content = new Buffer(content);
     } else if (!(content instanceof Buffer)) {
@@ -758,7 +758,7 @@ export class Queue {
   rpc(requestParameters: any): Promise<Message> {
     return new Promise<Message>((resolve, reject) => {
       var processRpc = () => {
-        var consumerTag;
+        var consumerTag: string;
         this._channel.consume(DIRECT_REPLY_TO_QUEUE, (resultMsg) => {
           this._channel.cancel(consumerTag);
           var result = new Message(resultMsg.content, resultMsg.fields);
@@ -1153,7 +1153,7 @@ export class Binding {
 
   static removeBindingsContaining(connectionPoint: Exchange | Queue): Promise<any> {
     var connection = connectionPoint._connection;
-    var promises = [];
+    var promises: Promise<void>[] = [];
     for (var bindingId in connection._bindings) {
 
       var binding: Binding = connection._bindings[bindingId];

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -96,7 +96,7 @@ export class Connection {
     return this.initialized;
   }
 
-  private tryToConnect(thisConnection: Connection,  retry: number, callback: (err: any) => void) {
+  private tryToConnect(thisConnection: Connection,  retry: number, callback: (err: any) => void): void {
     AmqpLib.connect(thisConnection.url, thisConnection.socketOptions, (err, connection) => {
       /* istanbul ignore if */
       if (err) {
@@ -316,7 +316,7 @@ export class Message {
     }
   }
 
-  setContent(content: any) {
+  setContent(content: any): void {
     if (typeof content === "string") {
       this.content = new Buffer(content);
     } else if (!(content instanceof Buffer)) {
@@ -335,7 +335,7 @@ export class Message {
     return content;
   }
 
-  sendTo(destination: Exchange | Queue, routingKey: string = "") {
+  sendTo(destination: Exchange | Queue, routingKey: string = ""): void {
     // inline function to send the message
     var sendMessage = () => {
       try {
@@ -373,19 +373,19 @@ export class Message {
     }
   }
 
-  ack(allUpTo?: boolean) {
+  ack(allUpTo?: boolean): void {
     if (this._channel !== undefined) {
       this._channel.ack(this._message, allUpTo);
     }
   }
 
-  nack(requeue?: boolean) {
+  nack(requeue?: boolean): void {
     if (this._channel !== undefined) {
       this._channel.nack(this._message, requeue);
     }
   }
 
-  reject(requeue?: boolean) {
+  reject(requeue?: boolean): void {
     if (this._channel !== undefined) {
       this._channel.reject(this._message, requeue);
     }
@@ -467,7 +467,7 @@ export class Exchange {
     });
   }
 
-  send(message: Message, routingKey = "") {
+  send(message: Message, routingKey = ""): void {
     message.sendTo(this, routingKey);
   }
 
@@ -676,7 +676,7 @@ export class Queue {
     this._initialize();
   }
 
-  _initialize() {
+  _initialize(): void {
     this.initialized = new Promise<Queue.InitializeResult>((resolve, reject) => {
       this._connection.initialized.then(() => {
         this._connection._connection.createChannel((err, channel) => {
@@ -725,7 +725,7 @@ export class Queue {
   /**
    * deprecated, use 'queue.send(message: Message)' instead
    */
-  publish(content: any, options: any = {}) {
+  publish(content: any, options: any = {}): void {
     // inline function to send the message
     var sendMessage = () => {
       try {
@@ -751,7 +751,7 @@ export class Queue {
     }
   }
 
-  send(message: Message, routingKey = "") {
+  send(message: Message, routingKey = ""): void {
     message.sendTo(this, routingKey);
   }
 
@@ -846,7 +846,7 @@ export class Queue {
     return this._consumerInitialized;
   }
 
-  _initializeConsumer() {
+  _initializeConsumer(): void {
     var processedMsgConsumer = (msg: AmqpLib.Message) => {
       try {
         /* istanbul ignore if */
@@ -1074,7 +1074,7 @@ export class Binding {
     this._initialize();
   }
 
-  _initialize() {
+  _initialize(): void {
     this.initialized = new Promise<Binding>((resolve, reject) => {
         if (this._destination instanceof Queue) {
           var queue = <Queue>this._destination;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "outDir": "./transpiled",
     "declaration": true,
     "rootDir": "./src",
-    "sourceMap": true,
-    "noImplicitAny": true
+    "sourceMap": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "./transpiled",
     "declaration": true,
     "rootDir": "./src",
-    "sourceMap": true
+    "sourceMap": true,
+    "noImplicitAny": true
   }
 }


### PR DESCRIPTION
When using the library via npm, and if you have the `noImplicitAny` option enabled, you get compiler errors. This should fix that. See attached txt for the errors.
[noImplicitAnyLog.txt](https://github.com/abreits/amqp-ts/files/279964/noImplicitAnyLog.txt)


There were some methods in the `.d.ts` of the package that lacked return type declarations. I added those to the source, and updated the definitions. Also added the `noImplicitAny` option to the `tsconfig.json` file, and added a few missing type declarations to the source to tighten things up.

The transpiled json output remains the same, since the types are only handled by Typescript anyways.