### PR TITLE
Added RPC call return Promise object feature

### DIFF
--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -431,6 +431,9 @@ var Exchange = (function () {
                     _this._channel.cancel(consumerTag);
                     var result = new Message(resultMsg.content, resultMsg.fields);
                     result.fields = resultMsg.fields;
+                    if (resultMsg.properties.headers && resultMsg.properties.headers.isError) {
+                        return reject(result);
+                    }
                     resolve(result);
                     //resolve(Queue._unpackMessageContent(result));
                 }, { noAck: true }, function (err, ok) {
@@ -695,7 +698,7 @@ var Queue = (function () {
                     _this._channel.cancel(consumerTag);
                     var result = new Message(resultMsg.content, resultMsg.fields);
                     result.fields = resultMsg.fields;
-                    if (resultMsg.fields.isError) {
+                    if (resultMsg.properties.headers && resultMsg.properties.headers.isError) {
                         return reject(result);
                     }
                     resolve(result);
@@ -793,7 +796,7 @@ var Queue = (function () {
                     var options_1 = {};
                     if (isPromise(result)) {
                         result.then(function (res) { return _sendToQueue(res, options_1); }, function (err) {
-                            options_1.isError = true;
+                            options_1.headers = { isError: true };
                             _sendToQueue(err, options_1);
                         });
                     }
@@ -825,7 +828,11 @@ var Queue = (function () {
                 if (!(result instanceof Message)) {
                     result = new Message(result, {});
                 }
-                _this._channel.sendToQueue(msg.properties.replyTo, result.content, isError ? { isError: true } : result.properties);
+                if (!result.properties.headers) {
+                    result.properties.headers = {};
+                }
+                result.properties.headers.isErorr = isError;
+                _this._channel.sendToQueue(msg.properties.replyTo, result.content, result.properties);
             };
             try {
                 var message = new Message(msg.content, msg.properties);

--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -25,6 +25,8 @@ var amqpts_log = new winston.Logger({
 exports.log = amqpts_log;
 // name for the RabbitMQ direct reply-to queue
 var DIRECT_REPLY_TO_QUEUE = "amq.rabbitmq.reply-to";
+// utility method
+var isPromise = function (obj) { return obj && obj.toString() === "[object Promise]"; };
 //----------------------------------------------------------------------------------------------------
 // Connection class
 //----------------------------------------------------------------------------------------------------
@@ -693,6 +695,9 @@ var Queue = (function () {
                     _this._channel.cancel(consumerTag);
                     var result = new Message(resultMsg.content, resultMsg.fields);
                     result.fields = resultMsg.fields;
+                    if (resultMsg.fields.isError) {
+                        return reject(result);
+                    }
                     resolve(result);
                     //resolve(Queue._unpackMessageContent(result));
                 }, { noAck: true }, function (err, ok) {
@@ -772,6 +777,10 @@ var Queue = (function () {
     Queue.prototype._initializeConsumer = function () {
         var _this = this;
         var processedMsgConsumer = function (msg) {
+            var _sendToQueue = function (result, options) {
+                result = Queue._packMessageContent(result, options);
+                _this._channel.sendToQueue(msg.properties.replyTo, result, options);
+            };
             try {
                 /* istanbul ignore if */
                 if (!msg) {
@@ -781,9 +790,16 @@ var Queue = (function () {
                 var result = _this._consumer(payload);
                 // check if there is a reply-to
                 if (msg.properties.replyTo) {
-                    var options = {};
-                    result = Queue._packMessageContent(result, options);
-                    _this._channel.sendToQueue(msg.properties.replyTo, result, options);
+                    var options_1 = {};
+                    if (isPromise(result)) {
+                        result.then(function (res) { return _sendToQueue(res, options_1); }, function (err) {
+                            options_1.isError = true;
+                            _sendToQueue(err, options_1);
+                        });
+                    }
+                    else {
+                        _sendToQueue(result, options_1);
+                    }
                 }
                 if (_this._consumerOptions.noAck !== true) {
                     _this._channel.ack(msg);
@@ -804,6 +820,13 @@ var Queue = (function () {
             }
         };
         var activateConsumerWrapper = function (msg) {
+            var _sendToQueue = function (result, isError) {
+                if (isError === void 0) { isError = false; }
+                if (!(result instanceof Message)) {
+                    result = new Message(result, {});
+                }
+                _this._channel.sendToQueue(msg.properties.replyTo, result.content, isError ? { isError: true } : result.properties);
+            };
             try {
                 var message = new Message(msg.content, msg.properties);
                 message.fields = msg.fields;
@@ -812,10 +835,12 @@ var Queue = (function () {
                 var result = _this._consumer(message);
                 // check if there is a reply-to
                 if (msg.properties.replyTo) {
-                    if (!(result instanceof Message)) {
-                        result = new Message(result, {});
+                    if (isPromise(result)) {
+                        result.then(function (res) { return _sendToQueue(res); }, function (err) { return _sendToQueue(err, true); });
                     }
-                    _this._channel.sendToQueue(msg.properties.replyTo, result.content, result.properties);
+                    else {
+                        _sendToQueue(result);
+                    }
                 }
             }
             catch (err) {

--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -831,7 +831,7 @@ var Queue = (function () {
                 if (!result.properties.headers) {
                     result.properties.headers = {};
                 }
-                result.properties.headers.isErorr = isError;
+                result.properties.headers.isError = isError;
                 _this._channel.sendToQueue(msg.properties.replyTo, result.content, result.properties);
             };
             try {

--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -427,26 +427,29 @@ var Exchange = (function () {
         return new Promise(function (resolve, reject) {
             var processRpc = function () {
                 var consumerTag;
-                _this._channel.consume(DIRECT_REPLY_TO_QUEUE, function (resultMsg) {
-                    _this._channel.cancel(consumerTag);
-                    var result = new Message(resultMsg.content, resultMsg.properties);
-                    result.fields = resultMsg.fields;
-                    if (resultMsg.properties.headers && resultMsg.properties.headers.isError) {
-                        return reject(result);
-                    }
-                    resolve(result);
-                    //resolve(Queue._unpackMessageContent(result));
-                }, { noAck: true }, function (err, ok) {
-                    /* istanbul ignore if */
-                    if (err) {
-                        reject(new Error("amqp-ts: Queue.rpc error: " + err.message));
-                    }
-                    else {
-                        // send the rpc request
-                        consumerTag = ok.consumerTag;
-                        var message = new Message(requestParameters, { replyTo: DIRECT_REPLY_TO_QUEUE });
-                        message.sendTo(_this, routingKey);
-                    }
+                _this._channel.assertQueue('', { autoDelete: true, exclusive: true }, function (err, qok) {
+                    _this._channel.consume(qok.queue, function (resultMsg) {
+                        _this._channel.cancel(consumerTag);
+                        // this._channel.deleteQueue(qok.queue);
+                        var result = new Message(resultMsg.content, resultMsg.properties);
+                        result.fields = resultMsg.fields;
+                        if (resultMsg.properties.headers && resultMsg.properties.headers.isError) {
+                            return reject(result);
+                        }
+                        resolve(result);
+                        //resolve(Queue._unpackMessageContent(result));
+                    }, { noAck: true }, function (err, ok) {
+                        /* istanbul ignore if */
+                        if (err) {
+                            reject(new Error("amqp-ts: Queue.rpc error: " + err.message));
+                        }
+                        else {
+                            // send the rpc request
+                            consumerTag = ok.consumerTag;
+                            var message = new Message(requestParameters, { replyTo: qok.queue });
+                            message.sendTo(_this, routingKey);
+                        }
+                    });
                 });
             };
             // execute sync when possible

--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -429,7 +429,7 @@ var Exchange = (function () {
                 var consumerTag;
                 _this._channel.consume(DIRECT_REPLY_TO_QUEUE, function (resultMsg) {
                     _this._channel.cancel(consumerTag);
-                    var result = new Message(resultMsg.content, resultMsg.fields);
+                    var result = new Message(resultMsg.content, resultMsg.properties);
                     result.fields = resultMsg.fields;
                     if (resultMsg.properties.headers && resultMsg.properties.headers.isError) {
                         return reject(result);
@@ -696,7 +696,7 @@ var Queue = (function () {
                 var consumerTag;
                 _this._channel.consume(DIRECT_REPLY_TO_QUEUE, function (resultMsg) {
                     _this._channel.cancel(consumerTag);
-                    var result = new Message(resultMsg.content, resultMsg.fields);
+                    var result = new Message(resultMsg.content, resultMsg.properties);
                     result.fields = resultMsg.fields;
                     if (resultMsg.properties.headers && resultMsg.properties.headers.isError) {
                         return reject(result);

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -480,7 +480,7 @@ export class Exchange {
         var consumerTag: string;
         this._channel.consume(DIRECT_REPLY_TO_QUEUE, (resultMsg) => {
           this._channel.cancel(consumerTag);
-          var result = new Message(resultMsg.content, resultMsg.fields);
+          var result = new Message(resultMsg.content, resultMsg.properties);
           result.fields = resultMsg.fields;
           if (resultMsg.properties.headers && resultMsg.properties.headers.isError) {
             return reject(result);
@@ -767,7 +767,7 @@ export class Queue {
         var consumerTag: string;
         this._channel.consume(DIRECT_REPLY_TO_QUEUE, (resultMsg) => {
           this._channel.cancel(consumerTag);
-          var result = new Message(resultMsg.content, resultMsg.fields);
+          var result = new Message(resultMsg.content, resultMsg.properties);
           result.fields = resultMsg.fields;
           if (resultMsg.properties.headers && resultMsg.properties.headers.isError) {
             return reject(result);

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -913,7 +913,7 @@ export class Queue {
         if(!result.properties.headers) {
           result.properties.headers = {};
         }
-        result.properties.headers.isErorr = isError;
+        result.properties.headers.isError = isError;
         this._channel.sendToQueue(msg.properties.replyTo, result.content, result.properties);
       };
 

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -858,8 +858,20 @@ export class Queue {
         // check if there is a reply-to
         if (msg.properties.replyTo) {
           var options: any = {};
-          result = Queue._packMessageContent(result, options);
-          this._channel.sendToQueue(msg.properties.replyTo, result, options);
+         if(result instanceof Promise) {
+            result.then((res:any) => {
+              result = Queue._packMessageContent(res, options);
+              this._channel.sendToQueue(msg.properties.replyTo, result, options);
+            },
+            (err:any) => {
+              options.isError = true;
+              result = Queue._packMessageContent(err, options);
+              this._channel.sendToQueue(msg.properties.replyTo, result, options);
+            });
+          } else {
+            result = Queue._packMessageContent(result, options);
+            this._channel.sendToQueue(msg.properties.replyTo, result, options);
+          }
         }
 
         if (this._consumerOptions.noAck !== true) {


### PR DESCRIPTION
Now we can write this code.

```ts
queue.activateConsumer((msg:Message) => {

  return new Promise((resolve, reject) => {
      setTimout(() => resolve({key:'value'}), 1000);
  });

});
```