### PR TITLE
Fix copy/paste bug in deprecated startConsumer() function

### DIFF
--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -878,7 +878,7 @@ var Queue = (function () {
                     var options = {};
                     if (result instanceof Promise) {
                         result.then(function (resultValue) {
-                            resultValue = Queue._packMessageContent(result, options);
+                            resultValue = Queue._packMessageContent(resultValue, options);
                             _this._channel.sendToQueue(msg.properties.replyTo, resultValue, options);
                         }).catch(function (err) {
                             exports.log.log("error", "Queue.onMessage RPC promise returned error: " + err.message, { module: "amqp-ts" });

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -946,7 +946,7 @@ export class Queue {
           var options: any = {};
           if (result instanceof Promise) {
             result.then((resultValue) => {
-              resultValue = Queue._packMessageContent(result, options);
+              resultValue = Queue._packMessageContent(resultValue, options);
               this._channel.sendToQueue(msg.properties.replyTo, resultValue, options);
             }).catch((err) => {
               log.log("error", "Queue.onMessage RPC promise returned error: " + err.message, { module: "amqp-ts" });


### PR DESCRIPTION
If a message is received with the replyTo field set and the onMessage
function passed to startConsumer returns a promise, the value returned
by the promise won't be included in the reply message. Instead a JSON
version of the entire promise will be included instead. This fixes that.