### PR TITLE
Remove unusable routingKey argument from queue.send()

### DIFF
--- a/lib/amqp-ts.d.ts
+++ b/lib/amqp-ts.d.ts
@@ -104,7 +104,7 @@ export declare class Exchange {
     constructor(connection: Connection, name: string, type?: string, options?: Exchange.DeclarationOptions);
     _initialize(): void;
     /**
-     * deprecated, use 'exchange.send(message: Message)' instead
+     * deprecated, use 'exchange.send(message: Message, routingKey?: string)' instead
      */
     publish(content: any, routingKey?: string, options?: any): void;
     send(message: Message, routingKey?: string): void;
@@ -158,7 +158,7 @@ export declare class Queue {
      * deprecated, use 'queue.send(message: Message)' instead
      */
     publish(content: any, options?: any): void;
-    send(message: Message, routingKey?: string): void;
+    send(message: Message): void;
     rpc(requestParameters: any): Promise<Message>;
     prefetch(count: number): void;
     recover(): Promise<void>;

--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -455,7 +455,7 @@ var Exchange = (function () {
         this._connection._exchanges[this._name] = this;
     };
     /**
-     * deprecated, use 'exchange.send(message: Message)' instead
+     * deprecated, use 'exchange.send(message: Message, routingKey?: string)' instead
      */
     Exchange.prototype.publish = function (content, routingKey, options) {
         var _this = this;

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -502,7 +502,7 @@ export class Exchange {
   }
 
   /**
-   * deprecated, use 'exchange.send(message: Message)' instead
+   * deprecated, use 'exchange.send(message: Message, routingKey?: string)' instead
    */
   publish(content: any, routingKey = "", options: any = {}): void {
     if (typeof content === "string") {
@@ -838,8 +838,8 @@ export class Queue {
     }
   }
 
-  send(message: Message, routingKey = ""): void {
-    message.sendTo(this, routingKey);
+  send(message: Message): void {
+    message.sendTo(this);
   }
 
   rpc(requestParameters: any): Promise<Message> {


### PR DESCRIPTION
The queue.send() function always ignores the routingKey value that's
passed into it since the message is being sent directly to a queue. So
it makes no sense (and is confusing) to have it as an argument. I doubt
anyone is using the argument since it doesn't do anything.