### PR TITLE
Make replying to a message with the replyTo field set optional

### DIFF
--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -884,8 +884,8 @@ var Queue = /** @class */ (function () {
                 var result = _this._consumer(payload);
                 // convert the result to a promise if it isn't one already
                 Promise.resolve(result).then(function (resultValue) {
-                    // check if there is a reply-to
-                    if (msg.properties.replyTo) {
+                    // check if there is a reply-to and that the result from the consumer is not undefined or null
+                    if (msg.properties.replyTo && resultValue !== undefined && resultValue !== null) {
                         var options = {};
                         resultValue = Queue._packMessageContent(resultValue, options);
                         _this._channel.sendToQueue(msg.properties.replyTo, resultValue, options);
@@ -921,8 +921,8 @@ var Queue = /** @class */ (function () {
                 var result = _this._consumer(message);
                 // convert the result to a promise if it isn't one already
                 Promise.resolve(result).then(function (resultValue) {
-                    // check if there is a reply-to
-                    if (msg.properties.replyTo) {
+                    // check if there is a reply-to and that the result from the consumer is not undefined or null
+                    if (msg.properties.replyTo && resultValue !== undefined && resultValue !== null) {
                         if (!(resultValue instanceof Message)) {
                             resultValue = new Message(resultValue, {});
                         }

--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -884,8 +884,8 @@ var Queue = /** @class */ (function () {
                 var result = _this._consumer(payload);
                 // convert the result to a promise if it isn't one already
                 Promise.resolve(result).then(function (resultValue) {
-                    // check if there is a reply-to and that the result from the consumer is not undefined or null
-                    if (msg.properties.replyTo && resultValue !== undefined && resultValue !== null) {
+                    // check if there is a reply-to and that the result from the consumer is not null or undefined
+                    if (msg.properties.replyTo && resultValue != null) {
                         var options = {};
                         resultValue = Queue._packMessageContent(resultValue, options);
                         _this._channel.sendToQueue(msg.properties.replyTo, resultValue, options);
@@ -921,8 +921,8 @@ var Queue = /** @class */ (function () {
                 var result = _this._consumer(message);
                 // convert the result to a promise if it isn't one already
                 Promise.resolve(result).then(function (resultValue) {
-                    // check if there is a reply-to and that the result from the consumer is not undefined or null
-                    if (msg.properties.replyTo && resultValue !== undefined && resultValue !== null) {
+                    // check if there is a reply-to and that the result from the consumer is not null or undefined
+                    if (msg.properties.replyTo && resultValue != null) {
                         if (!(resultValue instanceof Message)) {
                             resultValue = new Message(resultValue, {});
                         }

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -943,8 +943,8 @@ export class Queue {
         var result = this._consumer(payload);
         // convert the result to a promise if it isn't one already
         Promise.resolve(result).then((resultValue) => {
-          // check if there is a reply-to
-          if (msg.properties.replyTo) {
+          // check if there is a reply-to and that the result from the consumer is not undefined or null
+          if (msg.properties.replyTo && resultValue !== undefined && resultValue !== null) {
             var options: any = {};
             resultValue = Queue._packMessageContent(resultValue, options);
             this._channel.sendToQueue(msg.properties.replyTo, resultValue, options);
@@ -980,8 +980,8 @@ export class Queue {
         var result = this._consumer(message);
         // convert the result to a promise if it isn't one already
         Promise.resolve(result).then((resultValue) => {
-          // check if there is a reply-to
-          if (msg.properties.replyTo) {
+          // check if there is a reply-to and that the result from the consumer is not undefined or null
+          if (msg.properties.replyTo && resultValue !== undefined && resultValue !== null) {
             if (!(resultValue instanceof Message)) {
               resultValue = new Message(resultValue, {});
             }

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -943,8 +943,8 @@ export class Queue {
         var result = this._consumer(payload);
         // convert the result to a promise if it isn't one already
         Promise.resolve(result).then((resultValue) => {
-          // check if there is a reply-to and that the result from the consumer is not undefined or null
-          if (msg.properties.replyTo && resultValue !== undefined && resultValue !== null) {
+          // check if there is a reply-to and that the result from the consumer is not null or undefined
+          if (msg.properties.replyTo && resultValue != null) {
             var options: any = {};
             resultValue = Queue._packMessageContent(resultValue, options);
             this._channel.sendToQueue(msg.properties.replyTo, resultValue, options);
@@ -980,8 +980,8 @@ export class Queue {
         var result = this._consumer(message);
         // convert the result to a promise if it isn't one already
         Promise.resolve(result).then((resultValue) => {
-          // check if there is a reply-to and that the result from the consumer is not undefined or null
-          if (msg.properties.replyTo && resultValue !== undefined && resultValue !== null) {
+          // check if there is a reply-to and that the result from the consumer is not null or undefined
+          if (msg.properties.replyTo && resultValue != null) {
             if (!(resultValue instanceof Message)) {
               resultValue = new Message(resultValue, {});
             }


### PR DESCRIPTION
There are situations where a consumer may not want to immediately
reply to a message even though the message has the replyTo field set.
This change allows a consumer to decide whether or not to reply simply
by not returning a value or message if it doesn't want to reply.