### PR TITLE
bug fix about 'ApplicationName'

### DIFF
--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -27,8 +27,7 @@ var winston = require("winston");
 var path = require("path");
 var os = require("os");
 var events_1 = require("events");
-var ApplicationName = process.env.AMQPTS_APPLICATIONNAME ||
-    (path.parse ? path.parse(process.argv[1]).name : path.basename(process.argv[1]));
+
 // create a custom winston logger for amqp-ts
 var amqp_log = new winston.Logger({
     transports: [
@@ -623,6 +622,7 @@ var Exchange = /** @class */ (function () {
         return this._connection._bindings[Binding.id(this, source, pattern)].delete();
     };
     Exchange.prototype.consumerQueueName = function () {
+        var ApplicationName = process.env.AMQPTS_APPLICATIONNAME || (process.argv.length >= 2 ? (path.parse ? path.parse(process.argv[1]).name : path.basename(process.argv[1])) : 'ampqtsApp');
         return this._name + "." + ApplicationName + "." + os.hostname() + "." + process.pid;
     };
     /**

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -15,9 +15,6 @@ import * as path from "path";
 import * as os from "os";
 import { EventEmitter } from "events";
 
-var ApplicationName = process.env.AMQPTS_APPLICATIONNAME ||
-    (path.parse ? path.parse(process.argv[1]).name : path.basename(process.argv[1]));
-
 // create a custom winston logger for amqp-ts
 var amqp_log = new winston.Logger({
   transports: [
@@ -653,6 +650,7 @@ export class Exchange {
   }
 
   consumerQueueName(): string {
+    const ApplicationName = process.env.AMQPTS_APPLICATIONNAME || (process.argv.length >= 2 ? (path.parse ? path.parse(process.argv[1]).name : path.basename(process.argv[1])) : 'amqptsApp');
     return this._name + "." + ApplicationName + "." + os.hostname() + "." + process.pid;
   }
 


### PR DESCRIPTION
https://github.com/abreits/amqp-ts/issues/20
It is also the content of the above issue.
This is a problem that occurred when using amqp-ts in electron.

import * as Amqp from "amqp-ts";

If the content is declared in app.ts and used, the application will refer to amqp-ts immediately at runtime,
This application will be assigned an ApplicationName. At this time, if the process.env.AMQPTS_APPLICATIONNAME value of the process environment is not assigned, the length of process.argv is not present, or is less than 1, an error inevitably occurs.

Since ApplicationName is not a global variable, we know that it is only used in the consumerQueueName method.

ApplicationName has a valid value only when the application is started and the startConsumer is executed as needed.

Therefore, modify to allocate AppliacationName when consumerQueueName method is called.